### PR TITLE
Local port config for multi-drone, port reconfiguration for state and video and temporary CamInfo to enable streaming. 

### DIFF
--- a/include/tello/tello.hpp
+++ b/include/tello/tello.hpp
@@ -160,7 +160,8 @@ public:
   */
   TelloCommandSender(
     const std::string & tello_ip,
-    const int port_state = 8890);
+    const int port_command = 8890,
+    const int port_command_client = 8890);
 
   /**
    * @brief Destroy the TelloCommandSender object
@@ -189,6 +190,15 @@ public:
    * @return true if the command was sent
   */
   bool entrySDKMode();
+
+  /**
+   * @brief Set State and Camera Stream Ports
+   * 
+   * @return true if command was sent
+   */
+  bool setPort(
+    const int port_state = 8890, 
+    const int port_camera = 11111);
 
   /**
    * @brief Takeoff the tello drone

--- a/src/tello/tello.cpp
+++ b/src/tello/tello.cpp
@@ -172,10 +172,10 @@ bool TelloStateReceiver::parseState(const std::string & data)
 }
 
 TelloCommandSender::TelloCommandSender(
-  const std::string & tello_ip, const int port_command)
+  const std::string & tello_ip, const int port_command, const int port_command_client)
 {
   // Create UDP socket to send commands
-  udp_socket_command_ = std::make_unique<SocketUDP>(tello_ip, port_command, port_command);
+  udp_socket_command_ = std::make_unique<SocketUDP>(tello_ip, port_command_client, port_command);
 
   // Send command to enter SDK mode
   if (!entrySDKMode()) {
@@ -209,6 +209,11 @@ bool TelloCommandSender::getTime(std::string & response)
 bool TelloCommandSender::entrySDKMode()
 {
   return sendControlCommand("command");
+}
+
+bool TelloCommandSender::setPort(const int port_state, const int port_camera)
+{
+  return sendControlCommand("port " + std::to_string(port_state) + " " + std::to_string(port_camera));
 }
 
 bool TelloCommandSender::takeoff()


### PR DESCRIPTION
Hi guys,

In order to get multi-drone to work, we need a fixed local client port for each connected tello to avoid port clashing. In the existing repository, this wasn't possible as the client port was set the same as the server port. 

- There is a new parameter `port_command_client` which is the client port 
- In sdk 3.0 (and possibly undocumented in sdk 2.0) there is a new command `port <state port> <cam stream port>` which allows the user to change the streaming port. This will allow the streaming of both state and camera stream to different ports on the local machine. I add the setPort function to tello
- Since it also takes the camera stream port, I changed the format of the camera url back to ip and port, and call setPort again if camera is enabled
- Added a sample hardcoded caminfo so I could stream locally since rviz/foxglove was complaining about invalid caminfo (taken from here: https://github.com/tentone/tello-ros2/blob/main/workspace/src/tello/resource/ost.yaml) 

I have verified that changing the state port and the camera port works on the tello EDU in ap mode over the wifi network. 

I have managed to fly with two tellos, although I'm having trouble with the teleop panel and one or both drones going into emergency mode on their own. 

EDIT: Just tried with mission_swarm.py and it seems to be working semi-smoothly now! 
