### PR TITLE
Add ament_index_cpp as dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
+  <test_depend>ament_index_cpp</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,12 +2,13 @@
 file(GLOB TEST_SOURCE "*_test.cpp")
 
 if(TEST_SOURCE)
+  find_package(ament_index_cpp REQUIRED)
   foreach(TEST_FILE ${TEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_FILE} NAME_WE)
 
     add_executable(${PROJECT_NAME}_${TEST_NAME} ${TEST_FILE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp ${PROJECT_NAME})
   endforeach()
 endif()
 
@@ -16,12 +17,13 @@ file(GLOB GTEST_SOURCE "*_gtest.cpp")
 
 if(GTEST_SOURCE)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_index_cpp REQUIRED)
 
   foreach(TEST_SOURCE ${GTEST_SOURCE})
     get_filename_component(TEST_NAME ${TEST_SOURCE} NAME_WE)
 
     ament_add_gtest(${PROJECT_NAME}_${TEST_NAME} ${TEST_SOURCE})
     ament_target_dependencies(${PROJECT_NAME}_${TEST_NAME} ${PROJECT_DEPENDENCIES})
-    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} gtest_main ${PROJECT_NAME})
+    target_link_libraries(${PROJECT_NAME}_${TEST_NAME} ament_index_cpp::ament_index_cpp gtest_main ${PROJECT_NAME})
   endforeach()
 endif()


### PR DESCRIPTION
Following from [aerostack2/#784](https://github.com/aerostack2/aerostack2/pull/784). This fix is necessary to compile this package on Jazzy. It would be nice if this could be merged on a Jazzy branch :)